### PR TITLE
Enable the doxygen search-engine

### DIFF
--- a/doxygen-conf/doxygen.conf.in
+++ b/doxygen-conf/doxygen.conf.in
@@ -1087,7 +1087,7 @@ MATHJAX_RELPATH        = http://www.mathjax.org/mathjax
 # typically be disabled. For large projects the javascript based search engine
 # can be slow, then enabling SERVER_BASED_SEARCH may provide a better solution.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 # When the SERVER_BASED_SEARCH tag is enabled the search engine will be
 # implemented using a PHP enabled web server instead of at the web client


### PR DESCRIPTION
This PR enables the doxygen default search-engine to increase the experience of exploring the carl-api.

![doxygen-search](https://cloud.githubusercontent.com/assets/1412344/25774129/e872ab90-3289-11e7-8c3e-5ab08a22989a.PNG)
